### PR TITLE
Add non-strict comparison to support ganache-cli

### DIFF
--- a/cli/eac.js
+++ b/cli/eac.js
@@ -382,6 +382,7 @@ Endowment: ${web3.fromWei(endowment.toString())}
     console.log("\n")
     const spinner = ora("Sending transaction! Waiting for a response...").start()
 
+
     temporalUnit === 1
       ? eacScheduler
         .blockSchedule(
@@ -397,7 +398,7 @@ Endowment: ${web3.fromWei(endowment.toString())}
         requiredDeposit
         )
         .then((receipt) => {
-          if (receipt.status !== '0x1') {
+          if (receipt.status != '0x1') {
             spinner.fail(`Transaction was mined but failed. No transaction scheduled.`)
             process.exit(1)
           }

--- a/cli/eac.js
+++ b/cli/eac.js
@@ -382,7 +382,6 @@ Endowment: ${web3.fromWei(endowment.toString())}
     console.log("\n")
     const spinner = ora("Sending transaction! Waiting for a response...").start()
 
-
     temporalUnit === 1
       ? eacScheduler
         .blockSchedule(


### PR DESCRIPTION
`ganache-cli` returns `1` as the receipt status, which in turn fails in this condition and doesn't allow for scheduling transactions.