### PR TITLE
Add JSON object option to scheduling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,31 @@ This is a part of eac.js family that includes
 * [eac.js-client](https://github.com/ethereum-alarm-clock/eac.js-client)
 * [eac.js-cli](https://github.com/ethereum-alarm-clock/eac.js-cli)
 
-Eac.js-cli is the command line tool that allows you to run your executing agent for the Ethereum Alarm Clock protocol.
+Eac.js-cli is the command line tool that allows you to schedule transactions or run a timenode 
+on the Ethereum Alarm Clock protocol.
 
 ## Running
+Download this repository locally using `git clone` and install packages from NPM:
+
+```
+git clone git@github.com:ethereum-alarm-clock/eac.js-cli.git
+cd eac.jc-cli
+npm i
+```
+
+You will need to install and run the latest version of the Parity client on the __kovan__
+network. Make sure to follow the steps to unlock a local account.
+
+After starting up your Parity node, you can start the execution client (Timenode)
+by using the `-c` option. This will use your default unlocked account as the account
+from which to begin executing transactions from.
+
+```
+node bin/eac.js -c
+```
+
+You can install globablly from NPM:
+
 install globally: `npm i -g eac.js-cli`  
 run from command line: `eac.js -c`  
 view options: `eac.js --h`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ from which to begin executing transactions from.
 node bin/eac.js -c
 ```
 
+If you would like to schedule instead you can use the `-s` flag to signify
+that you would like to enter the scheduling wizard. The wizard will walk you
+through the steps to enter in the required paramters for scheduling a new
+transaction with the alarm clock. If instead, you already know the parameters
+and would like to skip the wizard, use the `--json` flag and feed it a string 
+of the JSON object containing some or all of the following parameters in the example input"
+
+```
+node bin/eac.js -s --json '{
+    "temporalUnit": 1,
+    "recipient": "0x75E7F640bf6968b6f32C47a3Cd82C3C2C9dCae68",
+    "callData": "0x1337",
+    "callGas": 23,
+    "callValue": 1001,
+    "windowStart": 7770777,
+    "windowSize": 100,
+    "gasPrice": 12,
+    "fee": 9090,
+    "bounty": 8080,
+    "deposit": 707
+}'
+```
+
+## Install From NPM
 You can install globablly from NPM:
 
 install globally: `npm i -g eac.js-cli`  

--- a/cli/eac.js
+++ b/cli/eac.js
@@ -51,6 +51,7 @@ program
   .option("-s, --schedule", "schedules a transactions")
   .option("--block")
   .option("--timestamp")
+  .option("--json <object>", "Uses the parameters contained in <object> to schedule a transaction.")
   .option('-w, --wallet [path...]', 'specify the path to the keyfile you would like to unlock (For multiple wallet files, pass in each file with -w option)', function (path, paths) {
     paths.push(path);
     return paths;
@@ -355,32 +356,35 @@ const main = async (_) => {
     }
     if (!await eac.Util.checkForUnlockedAccount()) process.exit(1)
 
+    let scheduleParams = {}
+    if (program.json) scheduleParams = JSON.parse(program.json)
+
     const eacScheduler = await eac.scheduler()
 
     // Starts the scheduling wizard.
     clear()
     console.log("🧙 🧙 🧙  Schedule a transaction  🧙 🧙 🧙\n")
 
-    const temporalUnit = readTemporalUnit()
-    const toAddress = readRecipientAddress()
-    const callData = readCallData()
-    const callGas = readCallGas()
-    const callValue = readCallValue()
+    const temporalUnit = scheduleParams.temporalUnit || readTemporalUnit()
+    const toAddress = scheduleParams.recipient || readRecipientAddress()
+    const callData = scheduleParams.callData || readCallData()
+    const callGas = scheduleParams.callGas || readCallGas()
+    const callValue = scheduleParams.callValue || readCallValue()
     
     const currentBlockNumber = await eac.Util.getBlockNumber()
     
-    const windowStart = readWindowStart(currentBlockNumber)
-    const windowSize = readWindowSize()
+    const windowStart = scheduleParams.windowStart || readWindowStart(currentBlockNumber)
+    const windowSize = scheduleParam.windowSize || readWindowSize()
 
     if (windowStart < currentBlockNumber + defaultSchedulingValues.minimumPeriodBeforeSchedule) {
       console.log("That window start time is too soon!")
       process.exit(1)
     }
 
-    const gasPrice = readGasPrice()
-    const fee = readFee()
-    const bounty = readBounty()
-    const requiredDeposit = readDeposit()
+    const gasPrice = scheduleParams.gasPrice || readGasPrice()
+    const fee = scheduleParams.fee || readFee()
+    const bounty = scheduleParams.bounty ||  readBounty()
+    const requiredDeposit = scheduleParam.deposit || readDeposit()
 
     clear()
 

--- a/cli/eac.js
+++ b/cli/eac.js
@@ -374,7 +374,7 @@ const main = async (_) => {
     const currentBlockNumber = await eac.Util.getBlockNumber()
     
     const windowStart = scheduleParams.windowStart || readWindowStart(currentBlockNumber)
-    const windowSize = scheduleParam.windowSize || readWindowSize()
+    const windowSize = scheduleParams.windowSize || readWindowSize()
 
     if (windowStart < currentBlockNumber + defaultSchedulingValues.minimumPeriodBeforeSchedule) {
       console.log("That window start time is too soon!")
@@ -384,7 +384,7 @@ const main = async (_) => {
     const gasPrice = scheduleParams.gasPrice || readGasPrice()
     const fee = scheduleParams.fee || readFee()
     const bounty = scheduleParams.bounty ||  readBounty()
-    const requiredDeposit = scheduleParam.deposit || readDeposit()
+    const requiredDeposit = scheduleParams.deposit || readDeposit()
 
     clear()
 


### PR DESCRIPTION
This will make it easier to schedule with parameters set from the command line and avoiding the interactive prompts (in the case of errors, you are not able to go back, etc.). 

Also pushing some documentation to the README file about how to use it.